### PR TITLE
column_name is not a name when talking about scopes

### DIFF
--- a/lib/filterable.rb
+++ b/lib/filterable.rb
@@ -33,8 +33,8 @@ module Filterable
   end
 
   class_methods do
-    def filter_on(parameter, type:, column_name: parameter)
-      filters << Filter.new(parameter, type, column_name)
+    def filter_on(parameter, type:, internal_name: parameter)
+      filters << Filter.new(parameter, type, internal_name)
     end
 
     def filters

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -56,7 +56,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'it invalidates id' do
-    post = Post.create!(visible: false)
+    Post.create!(visible: false)
     Post.create!
     expected_json = { 'errors' => { 'id' => ['must be int or range'] } }
 
@@ -84,9 +84,18 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'it filters on named scope' do
-    post = Post.create!(expiration: 3.days.ago)
-    post2 = Post.create!(expiration: 1.days.ago)
+    Post.create!(expiration: 3.days.ago)
+    Post.create!(expiration: 1.days.ago)
     get('/posts', params: { filters: { expired_before: 2.days.ago } })
+
+    json = JSON.parse(@response.body)
+    assert_equal 1, json.size
+  end
+
+  test 'the param can have a different name from the internal name' do
+    post = Post.create!(title: 'hi')
+    Post.create!(title: 'friend')
+    get('/posts', params: { filters: { french_bread: post.title } })
 
     json = JSON.parse(@response.body)
     assert_equal 1, json.size

--- a/test/dummy/app/controllers/posts_controller.rb
+++ b/test/dummy/app/controllers/posts_controller.rb
@@ -12,6 +12,8 @@ class PostsController < ApplicationController
   filter_on :published_at, type: :datetime
   filter_on :expired_before, type: :scope
 
+  filter_on :french_bread, type: :string, internal_name: :title
+
   before_action :render_filter_errors, unless: :filters_valid?
 
   def index

--- a/test/filter_validator_test.rb
+++ b/test/filter_validator_test.rb
@@ -20,7 +20,6 @@ class FilterValidatorTest < ActiveSupport::TestCase
 
   test 'it validates decimals are numerical' do
     filter = Filterable::Filter.new(:hi, :decimal, :hi)
-    expected_messages = { hi: ["is not included in the list"] }
 
     validator = Filterable::FilterValidator.new([filter], { hi: 2.13 })
     assert validator.valid?


### PR DESCRIPTION
so now we call it the internal name. so far no one is using this, so I feel comfortable changing the name, but I will bump a major version

@AllPurposeName 
