### PR TITLE
Allow sort parameters not intended for filterable

### DIFF
--- a/lib/filterable.rb
+++ b/lib/filterable.rb
@@ -16,7 +16,7 @@ module Filterable
   end
 
   def sort_params
-    params.fetch(:sort, '').split(',')
+    params.fetch(:sort, '').split(',') if sorts_exist?
   end
 
   def filters_valid?
@@ -35,6 +35,10 @@ module Filterable
 
   def filters
     self.class.filters
+  end
+
+  def sorts_exist?
+    filters.any? { |filter| filter.is_a?(Sort) }
   end
 
   class_methods do

--- a/test/dummy/app/controllers/posts_controller.rb
+++ b/test/dummy/app/controllers/posts_controller.rb
@@ -31,7 +31,6 @@ class PostsController < ApplicationController
 
   before_action :render_filter_errors, unless: :filters_valid?
 
-
   sort_on :title, type: :string
   sort_on :priority, type: :string
 

--- a/test/filterable_test.rb
+++ b/test/filterable_test.rb
@@ -2,10 +2,11 @@ require 'test_helper'
 
 class FilterableTest < ActiveSupport::TestCase
   class MyClass
+    attr_accessor :params
     include Filterable
 
     def params
-      ActionController::Parameters.new({})
+      @params ||= ActionController::Parameters.new({})
     end
   end
 
@@ -26,5 +27,14 @@ class FilterableTest < ActiveSupport::TestCase
     MyClass.sort_on(:id, type: :int)
 
     assert_equal [:id], MyClass.filters.map(&:param)
+  end
+
+  test "it always allows sort parameters to flow through" do
+    MyClass.reset_filters
+    custom_sort = { sort: { attribute: "due_date", direction: "asc" } }
+    my_class = MyClass.new
+    my_class.params = custom_sort
+
+    assert_equal [], my_class.filtrate(Post.all)
   end
 end


### PR DESCRIPTION
Some cases may need a more complicated sort ability than filterable
offers. If a "sort" parameter is used, filterable would hijack the
request trying to parse sort_params out of the parameters whether or not
sort_on was being used at all. If the formatting is not identical on the
custom sort, filterable will throw an error similar to:

NoMethodError: undefined method `split' for {...}:ActionController::Parameters

This solution first checks to see if there is a sorted_on field defined
on the class level and does not try to parse sort_params if none have
been made.

Shortfalls: If a custom sort method is being used in conjunction with
filterable's sorting, there may be an issue since sort_on will define
something. Also, however less of a problem, if a custom sort is being
used elsewhere and the same custom sort parameter format is used during
filterables sort, there will be a surprising error.