### PR TITLE
[ZL-452] Support class inheritance

### DIFF
--- a/lib/procore-sift.rb
+++ b/lib/procore-sift.rb
@@ -47,6 +47,7 @@ module Sift
 
   def filters
     self.class.ancestors
+      .take_while { |klass| klass.name != "Sift" }
       .flat_map { |klass| klass.try(:filters) }
       .compact
       .uniq { |f| [f.param, f.class] }

--- a/lib/procore-sift.rb
+++ b/lib/procore-sift.rb
@@ -58,7 +58,10 @@ module Sift
   end
 
   def sort_fields
-    self.class.ancestors.flat_map { |klass| klass.try(:sort_fields) }.compact
+    self.class.ancestors
+      .take_while { |klass| klass.name != "Sift" }
+      .flat_map { |klass| klass.try(:sort_fields) }
+      .compact
   end
 
   class_methods do

--- a/lib/procore-sift.rb
+++ b/lib/procore-sift.rb
@@ -46,14 +46,10 @@ module Sift
   end
 
   def filters
-    self.class.ancestors.flat_map do |klass|
-      klass.try(:filters)
-    end.compact.uniq do |f|
-      [f.param, f.class]
-    self.class.ancestors.
-      flat_map { |klass| klass.try(:filters) }.
-      compact.
-      uniq { |f| [f.param, f.class] }
+    self.class.ancestors
+      .flat_map { |klass| klass.try(:filters) }
+      .compact
+      .uniq { |f| [f.param, f.class] }
   end
 
   def sorts_exist?

--- a/lib/procore-sift.rb
+++ b/lib/procore-sift.rb
@@ -50,7 +50,10 @@ module Sift
       klass.try(:filters)
     end.compact.uniq do |f|
       [f.param, f.class]
-    end
+    self.class.ancestors.
+      flat_map { |klass| klass.try(:filters) }.
+      compact.
+      uniq { |f| [f.param, f.class] }
   end
 
   def sorts_exist?

--- a/lib/procore-sift.rb
+++ b/lib/procore-sift.rb
@@ -46,9 +46,7 @@ module Sift
   end
 
   def filters
-    return self.class.filters if self.class.filters.any?
-
-    self.class.parent_filters
+    self.class.parent_filters + (self.class.try(:filters) || [])
   end
 
   def sorts_exist?
@@ -56,9 +54,7 @@ module Sift
   end
 
   def sort_fields
-    return self.class.sort_fields if self.class.sort_fields.any?
-
-    self.class.parent_sort_fields
+    self.class.parent_sort_fields + (self.class.try(:sort_fields) || [])
   end
 
   class_methods do
@@ -71,7 +67,7 @@ module Sift
     end
 
     def parent_filters
-      ancestors.detect { |klass| klass.respond_to?(:filters) && klass.filters.any? }&.filters || []
+      ancestors.flat_map { |klass| klass.try(:filters) }.compact
     end
 
     # TODO: this is only used in tests, can I kill it?
@@ -84,7 +80,7 @@ module Sift
     end
 
     def parent_sort_fields
-      ancestors.detect { |klass| klass.respond_to?(:sort_fields) && klass.sort_fields.any? }&.sort_fields || []
+      ancestors.flat_map { |klass| klass.try(:sort_fields) }.compact
     end
 
     def sort_on(parameter, type:, internal_name: parameter, scope_params: [])

--- a/test/controller_inheritance_test.rb
+++ b/test/controller_inheritance_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class PostsInheritanceTest < ActionDispatch::IntegrationTest
+  test "it works" do
+    post = Post.create!
+
+    get("/alt_posts")
+
+    json = JSON.parse(@response.body)
+    assert_equal 1, json.size
+    assert_equal(post.id, json.first["id"])
+  end
+
+  test "it inherits filter from parent controller" do
+    post = Post.create!
+    Post.create!
+
+    get("/alt_posts", params: { filters: { id: post.id } })
+
+    json = JSON.parse(@response.body)
+    assert_equal 1, json.size
+    assert_equal post.id, json.first["id"]
+  end
+
+  test "it inherits sort from parent controller" do
+    Post.create!(title: "z")
+    Post.create!(title: "a")
+
+    get("/alt_posts", params: { sort: "title" })
+
+    json = JSON.parse(@response.body, object_class: OpenStruct)
+    assert_equal ["a", "z"], json.map(&:title)
+  end
+
+  test "it overrides filter from parent controller" do
+    Post.create!(body: "hi")
+    Post.create!(body: "hello")
+    Post.create!(body: "hola")
+    get("/alt_posts", params: { filters: { french_bread: ["hi", "hello"] } })
+
+    json = JSON.parse(@response.body)
+    assert_equal 2, json.size
+  end
+
+  test "it overrides sort from parent controller" do
+    Post.create!(priority: 3)
+    Post.create!(priority: 1)
+    Post.create!(priority: 2)
+    get("/alt_posts", params: { sort: "foobar" })
+
+    json = JSON.parse(@response.body, object_class: OpenStruct)
+    assert_equal [1, 2, 3], json.map(&:priority)
+  end
+end

--- a/test/controller_inheritance_test.rb
+++ b/test/controller_inheritance_test.rb
@@ -4,7 +4,7 @@ class PostsInheritanceTest < ActionDispatch::IntegrationTest
   test "it works" do
     post = Post.create!
 
-    get("/alt_posts")
+    get("/posts_alt")
 
     json = JSON.parse(@response.body)
     assert_equal 1, json.size
@@ -15,7 +15,7 @@ class PostsInheritanceTest < ActionDispatch::IntegrationTest
     post = Post.create!
     Post.create!
 
-    get("/alt_posts", params: { filters: { id: post.id } })
+    get("/posts_alt", params: { filters: { id: post.id } })
 
     json = JSON.parse(@response.body)
     assert_equal 1, json.size
@@ -26,7 +26,7 @@ class PostsInheritanceTest < ActionDispatch::IntegrationTest
     Post.create!(title: "z")
     Post.create!(title: "a")
 
-    get("/alt_posts", params: { sort: "title" })
+    get("/posts_alt", params: { sort: "title" })
 
     json = JSON.parse(@response.body, object_class: OpenStruct)
     assert_equal ["a", "z"], json.map(&:title)
@@ -36,7 +36,7 @@ class PostsInheritanceTest < ActionDispatch::IntegrationTest
     Post.create!(body: "hi")
     Post.create!(body: "hello")
     Post.create!(body: "hola")
-    get("/alt_posts", params: { filters: { french_bread: ["hi", "hello"] } })
+    get("/posts_alt", params: { filters: { french_bread: ["hi", "hello"] } })
 
     json = JSON.parse(@response.body)
     assert_equal 2, json.size
@@ -46,7 +46,7 @@ class PostsInheritanceTest < ActionDispatch::IntegrationTest
     Post.create!(priority: 3)
     Post.create!(priority: 1)
     Post.create!(priority: 2)
-    get("/alt_posts", params: { sort: "foobar" })
+    get("/posts_alt", params: { sort: "foobar" })
 
     json = JSON.parse(@response.body, object_class: OpenStruct)
     assert_equal [1, 2, 3], json.map(&:priority)

--- a/test/controller_inheritance_test.rb
+++ b/test/controller_inheritance_test.rb
@@ -32,21 +32,21 @@ class PostsInheritanceTest < ActionDispatch::IntegrationTest
     assert_equal ["a", "z"], json.map(&:title)
   end
 
-  test "it overrides filter from parent controller" do
-    Post.create!(body: "hi")
-    Post.create!(body: "hello")
-    Post.create!(body: "hola")
-    get("/posts_alt", params: { filters: { french_bread: ["hi", "hello"] } })
+  test "it overrides inherited body filter with priority filter" do
+    Post.create!(priority: 3)
+    Post.create!(priority: 1)
+    Post.create!(priority: 2)
+    get("/posts_alt", params: { filters: { body: [2, 3] } })
 
     json = JSON.parse(@response.body)
     assert_equal 2, json.size
   end
 
-  test "it overrides sort from parent controller" do
+  test "it overrides inherited body sort with priority sort" do
     Post.create!(priority: 3)
     Post.create!(priority: 1)
     Post.create!(priority: 2)
-    get("/posts_alt", params: { sort: "foobar" })
+    get("/posts_alt", params: { sort: "body" })
 
     json = JSON.parse(@response.body, object_class: OpenStruct)
     assert_equal [1, 2, 3], json.map(&:priority)

--- a/test/controller_inheritance_test.rb
+++ b/test/controller_inheritance_test.rb
@@ -38,8 +38,8 @@ class PostsInheritanceTest < ActionDispatch::IntegrationTest
     Post.create!(priority: 2)
     get("/posts_alt", params: { filters: { body: [2, 3] } })
 
-    json = JSON.parse(@response.body)
-    assert_equal 2, json.size
+    json = JSON.parse(@response.body, object_class: OpenStruct)
+    assert_equal [3, 2], json.map(&:priority)
   end
 
   test "it overrides inherited body sort with priority sort" do

--- a/test/dummy/app/controllers/alt_posts_controller.rb
+++ b/test/dummy/app/controllers/alt_posts_controller.rb
@@ -1,4 +1,0 @@
-class AltPostsController < PostsController
-  filter_on :french_bread, type: :scope, internal_name: :body2, default: ->(c) { c.order(:body) }
-  sort_on :foobar, type: :string, internal_name: :priority
-end

--- a/test/dummy/app/controllers/alt_posts_controller.rb
+++ b/test/dummy/app/controllers/alt_posts_controller.rb
@@ -1,0 +1,4 @@
+class AltPostsController < PostsController
+  filter_on :french_bread, type: :scope, internal_name: :body2, default: ->(c) { c.order(:body) }
+  sort_on :foobar, type: :string, internal_name: :priority
+end

--- a/test/dummy/app/controllers/posts_alt_controller.rb
+++ b/test/dummy/app/controllers/posts_alt_controller.rb
@@ -1,0 +1,4 @@
+class PostsAltController < PostsController
+  filter_on :body, type: :int, internal_name: :priority
+  sort_on :body, type: :int, internal_name: :priority
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   resources :posts
+  resources :alt_posts
 end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   resources :posts
-  resources :alt_posts
+  resources :posts_alt
 end


### PR DESCRIPTION
Ticket: [ZL-452](https://procoretech.atlassian.net/browse/ZL-452)

This branch of Sift tested on Procore: https://github.com/procore/procore/pull/58006

# Description

Currently, Sift filters and sorts defined on a parent class are not inherited by their child classes. For example:
```ruby
class Vapid::ProjectsController
   filter_on :origin_id
end

class class Rest::ProjectsController < Vapid::ProjectsController; end
```
The filter _is_ defined on `Vapid::ProjectsController` but _not_ defined on `Rest::ProjectsController`. This is because Sift saves sorts and filters on the static class name of the controller on which it was defined, rather than its instance.

Inheritance of Sift filters and sorts is a necessary feature for the new Rest API architecture, which relies heavily on a hierarchy of controller inheritance. It is also a feature desired by Sift's users in the Procore codebase, who have hacked around the issue on a case by case basis to allow multiple controllers to inherit from a base controller with defined sorts and filters. For example,
https://github.com/procore/procore/blob/eb80ef781f07e1f8e26202f19cb08da21568fac6/app/controllers/concerns/incidents/shared_detail_filters.rb

To solve this issue for the general case, we have modified sift to additionally search for sorts and filters across the controller's ancestors.

After this PR has been merged, the hacks present in the `shared_detail_filters.rb` and other controllers should be removed when Sift's version is bumped in Procore.