### PR TITLE
Address Rubocop Discrepencies and Fix Rails 6 Issue

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -175,7 +175,7 @@ Style/FrozenStringLiteralComment:
     to help transition from Ruby 2.3.0 to Ruby 3.0.
   Enabled: false
 
-Style/FlipFlop:
+Lint/FlipFlop:
   Description: 'Checks for flip flops'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-flip-flops'
   Enabled: false
@@ -228,7 +228,7 @@ Style/LineEndConcatenation:
                  line end.
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Description: 'Limit lines to 80 characters.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
   Max: 150
@@ -312,7 +312,7 @@ Style/PerlBackrefs:
 Naming/PredicateName:
   Description: 'Check the names of predicate methods.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark'
-  NamePrefixBlacklist:
+  ForbiddenPrefixes:
     - is_
   Exclude:
     - spec/**/*
@@ -438,7 +438,7 @@ Style/RedundantBegin:
 
 # Layout
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Description: 'Here we check if the parameters on a multi-line method call or definition are aligned.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-double-indent'
   Enabled: false
@@ -495,7 +495,7 @@ Lint/CircularArgumentReference:
   Description: "Don't refer to the keyword argument in the default value."
   Enabled: false
 
-Lint/ConditionPosition:
+Layout/ConditionPosition:
   Description: >-
                  Checks for condition placed in a confusing position relative to
                  the keyword.
@@ -506,7 +506,7 @@ Lint/DeprecatedClassMethods:
   Description: 'Check for deprecated class method calls.'
   Enabled: false
 
-Lint/DuplicatedKey:
+Lint/DuplicatedHashKey:
   Description: 'Check for duplicate keys in hash literals.'
   Enabled: false
 
@@ -522,7 +522,7 @@ Lint/FormatParameterMismatch:
   Description: 'The number of parameters to format/sprint must match the fields.'
   Enabled: false
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Description: "Don't suppress exception."
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions'
   Enabled: false
@@ -603,7 +603,7 @@ Performance/ReverseEach:
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code'
   Enabled: false
 
-Performance/Sample:
+Style/Sample:
   Description: >-
                   Use `sample` instead of `shuffle.first`,
                   `shuffle.last`, and `shuffle[Fixnum]`.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -312,7 +312,7 @@ Style/PerlBackrefs:
 Naming/PredicateName:
   Description: 'Check the names of predicate methods.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark'
-  ForbiddenPrefixes:
+  NamePrefixBlacklist:
     - is_
   Exclude:
     - spec/**/*

--- a/lib/sift/filter_validator.rb
+++ b/lib/sift/filter_validator.rb
@@ -52,7 +52,7 @@ module Sift
 
     def to_type(filter)
       if filter.type == :boolean
-        if Rails.version.starts_with?("5")
+        if Rails.version.starts_with?('5') || Rails.version.starts_with?('6')
           ActiveRecord::Type::Boolean.new.cast(filter_params[filter.param])
         else
           ActiveRecord::Type::Boolean.new.type_cast_from_user(filter_params[filter.param])

--- a/lib/sift/value_parser.rb
+++ b/lib/sift/value_parser.rb
@@ -53,7 +53,7 @@ module Sift
     end
 
     def boolean_value
-      if Rails.version.starts_with?('5') || Rails.version.starts_with?('6')
+      if Rails.version.to_i >= 5
         ActiveRecord::Type::Boolean.new.cast(value)
       else
         ActiveRecord::Type::Boolean.new.type_cast_from_user(value)

--- a/lib/sift/value_parser.rb
+++ b/lib/sift/value_parser.rb
@@ -53,7 +53,7 @@ module Sift
     end
 
     def boolean_value
-      if Rails.version.starts_with?("5")
+      if Rails.version.starts_with?('5') || Rails.version.starts_with?('6')
         ActiveRecord::Type::Boolean.new.cast(value)
       else
         ActiveRecord::Type::Boolean.new.type_cast_from_user(value)

--- a/sift.gemspec
+++ b/sift.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry"
   s.add_development_dependency "rails", ">= 5.1"
   s.add_development_dependency "rake"
-  s.add_development_dependency "rubocop"
+  s.add_development_dependency "rubocop", "0.71.0"
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
## Changelog

* Update `rubocop` to 0.71.0 and update cop rules accordingly.
* Fix issue where a `ActiveRecord::Type::Boolean.new.type_cast_from_user` is erroneously called when Rails version is > `6.0.0`. 

## Follow Ups

* Pull out explicit version checking into a single location. 

## Testing Requirements

- [ ] Travis is green. 