### PR TITLE
Adding Support for jsonb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-## 0.13.1
+## 0.14.0
 
 * Add support for `jsonb` type (only for PostgreSQL)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## 0.13.1
+
+* Add support for `jsonb` type (only for PostgreSQL)
+
+## 0.13.0
+
 ## 0.12.0
 
 * Change gem name to procore-sift

--- a/README.md
+++ b/README.md
@@ -123,6 +123,32 @@ The following types support ranges
 * time
 * datetime
 
+### Filter on jsonb column
+
+Usually JSONB columns stores values as an Array or an Object (key-value), in both cases the parameter needs to be sent in a JSON format
+
+**Array**
+
+It should be sent an array in the URL Query parameters
+ * `?filters[metadata]=[1,2]`
+
+**key-value**
+
+It can be passed one or more Key values:
+ * `?filters[metadata]={"data_1":"test"}`
+ * `?filters[metadata]={"data_1":"test","data_2":[1,2]}`
+
+When the value is an array, it will filter records with those values or more, for example:
+
+* `?filters[metadata]={"data_2":[1,2]}`
+
+Will return records with next values stored in the JSONB column `metadata`:
+```ruby
+{ data_2: [1,2] }
+{ data_2: [1,2,3] }
+```
+
+
 ### Filter on JSON Array
 `int` type filters support sending the values as an array in the URL Query parameters. For example `?filters[id]=[1,2]`. This is a way to keep payloads smaller for GET requests. When URI encoded this will become `filters%5Bid%5D=%5B1,2%5D` which is much smaller the standard format of `filters%5Bid%5D%5B%5D=1&&filters%5Bid%5D%5B%5D=2`.
 

--- a/README.md
+++ b/README.md
@@ -136,14 +136,18 @@ It should be sent an array in the URL Query parameters
 
 It can be passed one or more Key values:
  * `?filters[metadata]={"data_1":"test"}`
- * `?filters[metadata]={"data_1":"test","data_2":[1,2]}`
+ * `?filters[metadata]={"data_1":"test","data_2":"[1,2]"}`
 
 When the value is an array, it will filter records with those values or more, for example:
 
-* `?filters[metadata]={"data_2":[1,2]}`
+* `?filters[metadata]={"data_2":"[1,2]"}`
 
 Will return records with next values stored in the JSONB column `metadata`:
 ```ruby
+{ data_2: 1 }
+{ data_2: 2 }
+{ data_2: [1] }
+{ data_2: [2] }
 { data_2: [1,2] }
 { data_2: [1,2,3] }
 ```

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Every filter must have a type, so that Sift knows what to do with it. The curren
 * time - Filter on a time column
 * datetime - Filter on a datetime column
 * scope - Filter on an ActiveRecord scope
+* jsonb - Filter on a jsonb column (supported only in PostgreSQL)
 
 ### Filter on Scopes
 Just as your filter values are used to scope queries on a column, values you

--- a/lib/procore-sift.rb
+++ b/lib/procore-sift.rb
@@ -10,6 +10,7 @@ require "sift/scope_handler"
 require "sift/where_handler"
 require "sift/validators/valid_int_validator"
 require "sift/validators/valid_date_range_validator"
+require "sift/validators/valid_json_validator"
 
 module Sift
   extend ActiveSupport::Concern

--- a/lib/sift/parameter.rb
+++ b/lib/sift/parameter.rb
@@ -13,7 +13,8 @@ module Sift
       {
         supports_boolean: supports_boolean?,
         supports_ranges: supports_ranges?,
-        supports_json: supports_json?
+        supports_json: supports_json?,
+        supports_json_object: supports_json_object?
       }
     end
 
@@ -32,7 +33,11 @@ module Sift
     end
 
     def supports_json?
-      type == :int
+      [:int, :jsonb].include?(type)
+    end
+
+    def supports_json_object?
+      type == :jsonb
     end
 
     def supports_boolean?

--- a/lib/sift/type_validator.rb
+++ b/lib/sift/type_validator.rb
@@ -4,6 +4,7 @@ module Sift
     DATETIME_RANGE_PATTERN = { format: { with: /\A.+(?:[^.]\.\.\.[^.]).+\z/, message: "must be a range" }, valid_date_range: true }.freeze
     DECIMAL_PATTERN = { numericality: true, allow_nil: true }.freeze
     BOOLEAN_PATTERN = { inclusion: { in: [true, false] }, allow_nil: true }.freeze
+    JSON_PATTERN = { valid_json: true }.freeze
 
     WHITELIST_TYPES = [:int,
                        :decimal,
@@ -13,7 +14,8 @@ module Sift
                        :date,
                        :time,
                        :datetime,
-                       :scope].freeze
+                       :scope,
+                       :jsonb].freeze
 
     def initialize(param, type)
       @param = param
@@ -32,6 +34,8 @@ module Sift
         DECIMAL_PATTERN
       when :boolean
         BOOLEAN_PATTERN
+      when :jsonb
+        JSON_PATTERN
       end
     end
 

--- a/lib/sift/validators/valid_json_validator.rb
+++ b/lib/sift/validators/valid_json_validator.rb
@@ -1,0 +1,14 @@
+class ValidJsonValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    record.errors.add attribute, "must be a valid JSON" unless valid_json?(value)
+  end
+
+  private
+
+  def valid_json?(value)
+    value = value.strip if value.is_a?(String)
+    JSON.parse(value)
+  rescue JSON::ParserError
+    false
+  end
+end

--- a/lib/sift/value_parser.rb
+++ b/lib/sift/value_parser.rb
@@ -5,6 +5,7 @@ module Sift
       @supports_boolean = options.fetch(:supports_boolean, false)
       @supports_ranges = options.fetch(:supports_ranges, false)
       @supports_json = options.fetch(:supports_json, false)
+      @supports_json_object = options.fetch(:supports_json_object, false)
       @value = normalized_value(value, type)
     end
 
@@ -15,26 +16,30 @@ module Sift
         elsif parse_as_boolean?
           boolean_value
         elsif parse_as_json?
-          array_from_json
+          supports_json_object ? parse_json : array_from_json
         else
           value
         end
     end
 
+    def parse_json
+      JSON.parse(value)
+    rescue JSON::ParserError
+      value
+    end
+
     def array_from_json
-      result = JSON.parse(value)
+      result = parse_json
       if result.is_a?(Array)
         result
       else
         value
       end
-    rescue JSON::ParserError
-      value
     end
 
     private
 
-    attr_reader :value, :type, :supports_boolean, :supports_json, :supports_ranges
+    attr_reader :value, :type, :supports_boolean, :supports_json, :supports_json_object, :supports_ranges
 
     def parse_as_range?(raw_value=value)
       supports_ranges && raw_value.to_s.include?("...")

--- a/lib/sift/value_parser.rb
+++ b/lib/sift/value_parser.rb
@@ -16,20 +16,29 @@ module Sift
         elsif parse_as_boolean?
           boolean_value
         elsif parse_as_json?
-          supports_json_object ? parse_json : array_from_json
+          supports_json_object ? parse_json_and_values : array_from_json
         else
           value
         end
     end
 
-    def parse_json
-      JSON.parse(value)
+    def parse_json(string)
+      JSON.parse(string)
     rescue JSON::ParserError
-      value
+      string
+    end
+
+    def parse_json_and_values
+      parsed_jsonb = parse_json(value)
+      return parsed_jsonb if parsed_jsonb.is_a?(Array) || parsed_jsonb.is_a?(String)
+
+      parsed_jsonb.each_with_object({}) do |key_value, hash|
+        hash[key_value.first] = parse_json(key_value.last.to_s)
+      end
     end
 
     def array_from_json
-      result = parse_json
+      result = parse_json(value)
       if result.is_a?(Array)
         result
       else

--- a/lib/sift/version.rb
+++ b/lib/sift/version.rb
@@ -1,3 +1,3 @@
 module Sift
-  VERSION = "0.13.0".freeze
+  VERSION = "0.13.1".freeze
 end

--- a/lib/sift/version.rb
+++ b/lib/sift/version.rb
@@ -1,3 +1,3 @@
 module Sift
-  VERSION = "0.13.1".freeze
+  VERSION = "0.14.0".freeze
 end

--- a/lib/sift/where_handler.rb
+++ b/lib/sift/where_handler.rb
@@ -5,7 +5,28 @@ module Sift
     end
 
     def call(collection, value, _params, _scope_params)
-      collection.where(@param.internal_name => value)
+      if @param.type == :jsonb
+        apply_jsonb_conditions(collection, value)
+      else
+        collection.where(@param.internal_name => value)
+      end
+    end
+
+    private
+
+    def apply_jsonb_conditions(collection, value)
+      return collection.where("#{@param.internal_name} @> ?", val.to_s) if value.is_a?(Array)
+
+      value.each do |key, val|
+        condition = if val.is_a?(Array)
+          "#{@param.internal_name} @> '{\"#{key}\": [?]}'"
+        else # Single Value
+          val = val.to_s
+          "#{@param.internal_name}->>'#{key}' = ?"
+        end
+        collection = collection.where(condition, val)
+      end
+      collection
     end
   end
 end

--- a/lib/sift/where_handler.rb
+++ b/lib/sift/where_handler.rb
@@ -19,7 +19,7 @@ module Sift
 
       value.each do |key, val|
         condition = if val.is_a?(Array)
-          "#{@param.internal_name} @> '{\"#{key}\": [?]}'"
+          "('{' || TRANSLATE(#{@param.internal_name}->>'#{key}', '[]','') || '}')::int[] && ARRAY[?]"
         else # Single Value
           val = val.to_s
           "#{@param.internal_name}->>'#{key}' = ?"

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -282,4 +282,27 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     json = JSON.parse(@response.body)
     assert_equal [post1.id], (json.map { |post| post.fetch("id") })
   end
+
+  test "it filters on metadata by jsonb key" do
+    post = Post.create!(metadata: { 'a' => 4 }.to_json)
+    Post.create!(metadata: { 'b' => 5 }.to_json)
+
+    # Stubs are needed because the dummy app DB is not PostgreSQL
+    instance_mock = Minitest::Mock.new
+    instance_mock.expect :call, Post.where(id: post.id), [Post.all, Hash, ActionController::Parameters, Array]
+
+    class_mock = Minitest::Mock.new
+    class_mock.expect :call, instance_mock, [Sift::Parameter]
+
+    Sift::WhereHandler.stub :new, class_mock, [Sift::Parameter] do
+      get("/posts", params: { filters: { metadata: { 'a' => 4 }.to_json } })
+
+      json = JSON.parse(@response.body)
+      assert_equal 1, json.size
+      assert_equal post.id, json.first["id"]
+    end
+
+    assert_mock class_mock
+    assert_mock instance_mock
+  end
 end

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -283,7 +283,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     assert_equal [post1.id], (json.map { |post| post.fetch("id") })
   end
 
-  test "it filters on metadata by jsonb key" do
+  test "it filters on metadata by jsonb key-value" do
     post = Post.create!(metadata: { 'a' => 4 }.to_json)
     Post.create!(metadata: { 'b' => 5 }.to_json)
 
@@ -296,6 +296,29 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
 
     Sift::WhereHandler.stub :new, class_mock, [Sift::Parameter] do
       get("/posts", params: { filters: { metadata: { 'a' => 4 }.to_json } })
+
+      json = JSON.parse(@response.body)
+      assert_equal 1, json.size
+      assert_equal post.id, json.first["id"]
+    end
+
+    assert_mock class_mock
+    assert_mock instance_mock
+  end
+
+  test "it filters on metadata by jsonb array" do
+    post = Post.create!(metadata: [1,2,3].to_json)
+    Post.create!(metadata: [4,5,6].to_json)
+
+    # Stubs are needed because the dummy app DB is not PostgreSQL
+    instance_mock = Minitest::Mock.new
+    instance_mock.expect :call, Post.where(id: post.id), [Post.all, Array, ActionController::Parameters, Array]
+
+    class_mock = Minitest::Mock.new
+    class_mock.expect :call, instance_mock, [Sift::Parameter]
+
+    Sift::WhereHandler.stub :new, class_mock, [Sift::Parameter] do
+      get("/posts", params: { filters: { metadata: [1,2].to_json } })
 
       json = JSON.parse(@response.body)
       assert_equal 1, json.size

--- a/test/dummy/app/controllers/posts_controller.rb
+++ b/test/dummy/app/controllers/posts_controller.rb
@@ -12,6 +12,7 @@ class PostsController < ApplicationController
   filter_on :published_at, type: :datetime
   filter_on :expired_before, type: :scope
   filter_on :expired_before_and_priority, type: :scope, scope_params: [:priority]
+  filter_on :metadata, type: :jsonb
 
   filter_on :french_bread, type: :string, internal_name: :title
   filter_on :body2, type: :scope, internal_name: :body2, default: ->(c) { c.order(:body) }

--- a/test/dummy/db/migrate/20200512151604_add_metadata_to_posts.rb
+++ b/test/dummy/db/migrate/20200512151604_add_metadata_to_posts.rb
@@ -1,0 +1,5 @@
+class AddMetadataToPosts < ActiveRecord::Migration[5.0]
+  def change
+    add_column :posts, :metadata, :json
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160909014304) do
+ActiveRecord::Schema.define(version: 20200512151604) do
   create_table "posts", force: :cascade do |t|
     t.integer  "priority"
     t.decimal  "rating"
@@ -22,5 +22,6 @@ ActiveRecord::Schema.define(version: 20160909014304) do
     t.datetime "published_at"
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
+    t.json "metadata"
   end
 end

--- a/test/filter_validator_test.rb
+++ b/test/filter_validator_test.rb
@@ -236,4 +236,31 @@ class FilterValidatorTest < ActiveSupport::TestCase
     assert validator.valid?
     assert_equal Hash.new, validator.errors.messages
   end
+
+  test "it allows jsonb" do
+    filter = Sift::Filter.new(:metadata, :jsonb, :metadata, nil)
+
+    validator = Sift::FilterValidator.build(
+      filters: [filter],
+      sort_fields: [],
+      filter_params: { metadata: "{\"a\":4}" },
+      sort_params: [],
+    )
+    assert validator.valid?
+    assert_equal Hash.new, validator.errors.messages
+  end
+
+  test "invalid jsonb when the value is not correct" do
+    filter = Sift::Filter.new(:metadata, :jsonb, :metadata, nil)
+    expected_messages = { metadata: ["must be a valid JSON"] }
+
+    validator = Sift::FilterValidator.build(
+      filters: [filter],
+      sort_fields: [],
+      filter_params: { metadata: "\"a\":4" },
+      sort_params: [],
+    )
+    assert !validator.valid?
+    assert_equal expected_messages, validator.errors.messages
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ ENV["RAILS_ENV"] = "test"
 require File.expand_path("../test/dummy/config/environment.rb", __dir__)
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 require "rails/test_help"
+require 'minitest/autorun'
 
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.

--- a/test/type_validator_test.rb
+++ b/test/type_validator_test.rb
@@ -40,4 +40,18 @@ class TypeValidatorTest < ActiveSupport::TestCase
 
     assert_equal expected_validation, validator.validate
   end
+
+  test "it accepts a json array for type jsonb" do
+    validator = Sift::TypeValidator.new("[1,10]", :jsonb)
+    expected_validation = { valid_json: true }
+
+    assert_equal expected_validation, validator.validate
+  end
+
+  test "it accepts a json object for type jsonb" do
+    validator = Sift::TypeValidator.new("{\"a\":4}", :jsonb)
+    expected_validation = { valid_json: true }
+
+    assert_equal expected_validation, validator.validate
+  end
 end

--- a/test/value_parser_test.rb
+++ b/test/value_parser_test.rb
@@ -43,6 +43,17 @@ class FilterTest < ActiveSupport::TestCase
     assert_equal json_string, parser.parse
   end
 
+  test "JSON parsing objects when supports_json_object is true" do
+    options = {
+      supports_json: true,
+      supports_json_object: true
+    }
+    json_string = "{\"a\":4}"
+    parser = Sift::ValueParser.new(value: json_string, options: options)
+
+    assert_equal JSON.parse(json_string), parser.parse
+  end
+
   test "With options a range string of integers results in a range" do
     options = {
       supports_ranges: true,

--- a/test/value_parser_test.rb
+++ b/test/value_parser_test.rb
@@ -48,10 +48,11 @@ class FilterTest < ActiveSupport::TestCase
       supports_json: true,
       supports_json_object: true
     }
-    json_string = "{\"a\":4}"
+    json_string = "{\"a\":\"abcd\"}"
     parser = Sift::ValueParser.new(value: json_string, options: options)
+    parsed_expected = JSON.parse(json_string)
 
-    assert_equal JSON.parse(json_string), parser.parse
+    assert_equal parsed_expected, parser.parse
   end
 
   test "JSON parsing objects when supports_json_object is true and the one json value is an array" do

--- a/test/value_parser_test.rb
+++ b/test/value_parser_test.rb
@@ -54,6 +54,18 @@ class FilterTest < ActiveSupport::TestCase
     assert_equal JSON.parse(json_string), parser.parse
   end
 
+  test "JSON parsing objects when supports_json_object is true and the one json value is an array" do
+    options = {
+      supports_json: true,
+      supports_json_object: true
+    }
+    json_string = "{\"a\":\"[1,2]\"}"
+    parser = Sift::ValueParser.new(value: json_string, options: options)
+
+    parsed_expected = { "a" => [1,2] }
+    assert_equal parsed_expected, parser.parse
+  end
+
   test "With options a range string of integers results in a range" do
     options = {
       supports_ranges: true,


### PR DESCRIPTION
## Description
### Changes
- Adding new type: `jsonb` that expects a JSON value
- Bump version to  0.14.0
- Updating Changelog
- Updating Readme
- Adding new tests for `jsonb` type

### Query Samples

Single value
```.sql
WHERE (custom_fields->>'927' = 'true')
```

Array Value
```.sql
WHERE (('{' || TRANSLATE(custom_fields->>'917', '[]','') || '}')::int[] && ARRAY[688,689,690])
```