### PR TITLE
Allows mutating filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,24 @@ The following types support ranges
 * time
 * datetime
 
+### Mutating Filters
+Filters can be mutated before the filter is applied.  This is useful, for example, if you need to adjust the time zone of a `datetime` range filter.
+
+```ruby
+
+class PostsController < ApplicationController
+  include Sift
+
+  filter_on :expiration, type: :datetime, tap: ->(value, params) {
+    value.split("...").
+      map do |str|
+        str.to_date.in_time_zone(LOCAL_TIME_ZONE)
+      end.
+      join("...")
+  }
+end
+```
+
 ### Filter on jsonb column
 
 Usually JSONB columns stores values as an Array or an Object (key-value), in both cases the parameter needs to be sent in a JSON format

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The following types support ranges
 * datetime
 
 ### Mutating Filters
-Filters can be mutated before the filter is applied.  This is useful, for example, if you need to adjust the time zone of a `datetime` range filter.
+Filters can be mutated before the filter is applied using the `tap` argument. This is useful, for example, if you need to adjust the time zone of a `datetime` range filter.
 
 ```ruby
 

--- a/lib/procore-sift.rb
+++ b/lib/procore-sift.rb
@@ -66,8 +66,8 @@ module Sift
   end
 
   class_methods do
-    def filter_on(parameter, type:, internal_name: parameter, default: nil, validate: nil, scope_params: [])
-      filters << Filter.new(parameter, type, internal_name, default, validate, scope_params)
+    def filter_on(parameter, type:, internal_name: parameter, default: nil, validate: nil, scope_params: [], tap: nil)
+      filters << Filter.new(parameter, type, internal_name, default, validate, scope_params, tap)
     end
 
     def filters

--- a/test/dummy/app/controllers/posts_controller.rb
+++ b/test/dummy/app/controllers/posts_controller.rb
@@ -1,6 +1,8 @@
 class PostsController < ApplicationController
   include Sift
 
+  LOCAL_TIME_ZONE = "America/New_York"
+
   filter_on :id, type: :int
   filter_on :priority, type: :int
   filter_on :rating, type: :decimal
@@ -16,6 +18,14 @@ class PostsController < ApplicationController
 
   filter_on :french_bread, type: :string, internal_name: :title
   filter_on :body2, type: :scope, internal_name: :body2, default: ->(c) { c.order(:body) }
+
+  filter_on :expiration, type: :datetime, tap: ->(value, params) {
+    value.split("...").
+      map do |str|
+        str.to_date.in_time_zone(LOCAL_TIME_ZONE)
+      end.
+      join("...")
+  }
 
   # rubocop:disable Style/RescueModifier
   filter_on :id_array, type: :int, internal_name: :id, validate: ->(validator) {

--- a/test/filter_test.rb
+++ b/test/filter_test.rb
@@ -75,4 +75,12 @@ class FilterTest < ActiveSupport::TestCase
 
     assert_equal expected_validation, filter.validation(nil)
   end
+
+  test "it accepts a tap parameter" do
+    filter = Sift::Filter.new("hi", :boolean, "hi", nil, nil, [], ->(_value, _params) {
+      false
+    })
+
+    assert_equal false, filter.instance_variable_get("@tap").call(true, {})
+  end
 end

--- a/test/filtrator_test.rb
+++ b/test/filtrator_test.rb
@@ -197,4 +197,39 @@ class FiltratorTest < ActiveSupport::TestCase
 
     assert_equal Post.expired_before_ordered_by_body("2017-12-31", :asc).to_a, collection.to_a
   end
+
+  test "it can utilize the tap parameter to mutate a param" do
+    Post.create!(priority: 5, expiration: "2017-01-01T00:00:00+00:00")
+    Post.create!(priority: 5, expiration: "2017-01-02T00:00:00+00:00")
+    Post.create!(priority: 7, expiration: "2020-10-20T00:00:00+00:00")
+
+    filter = Sift::Filter.new(
+      :expiration,
+      :datetime,
+      :expiration,
+      nil,
+      nil,
+      [],
+      ->(value, params) {
+        if params[:mutate].present?
+          "2017-01-02T00:00:00+00:00...2017-01-02T00:00:00+00:00"
+        else
+          value
+        end
+      },
+    )
+    collection = Sift::Filtrator.filter(
+      Post.all,
+      {
+        filters: { expiration: "2017-01-01...2017-01-01" },
+        mutate: true
+      },
+      [filter],
+    )
+
+    assert_equal 3, Post.count
+    assert_equal 1, collection.count
+
+    assert_equal Post.where(expiration: "2017-01-02").to_a, collection.to_a
+  end
 end


### PR DESCRIPTION
Adds a `tap` method to `filter_on`, to allow mutating the filter parameters before they are applied to the collection.

This supports a use case in which we don't necessarily want to change the filters the consumer sends, but we need to normalize the filters in some way before applying.  For example, consider a client that sends filters daterange filters in UTC, but applied to some data in a localized time zone.

This can currently be accomplished using a type of `:scope`; however, then the filters will not be validated and custom validation is required. 