### PR TITLE
Allows mutating filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,34 @@
 ## Unreleased
 
+## 0.16.0
+
+- Adds a `tap` method to `filter_on` to support mutating filter values
+
 ## 0.15.0
 
-* Support for `null` filtering by `jsonb` type
+- Support for `null` filtering by `jsonb` type
 
 ## 0.14.0
 
-* Add support for `jsonb` type (only for PostgreSQL)
+- Add support for `jsonb` type (only for PostgreSQL)
 
 ## 0.13.0
 
 ## 0.12.0
 
-* Change gem name to procore-sift
+- Change gem name to procore-sift
 
 ## 0.11.0
 
-* Rename gem to Sift
-* Add normalization and validation for date range values
-* Tightened up ValueParser by privatizing unnecessarily public attr_accessors
+- Rename gem to Sift
+- Add normalization and validation for date range values
+- Tightened up ValueParser by privatizing unnecessarily public attr_accessors
 
 ## 0.10.0
 
-* Support for integer filtering of JSON arrays
+- Support for integer filtering of JSON arrays
 
 ## 0.9.2 (January 26, 2018)
 
-* Rename gem to Brita
-* Publish to RubyGems
+- Rename gem to Brita
+- Publish to RubyGems

--- a/README.md
+++ b/README.md
@@ -130,6 +130,24 @@ The following types support ranges
 - time
 - datetime
 
+### Mutating Filters
+Filters can be mutated before the filter is applied using the `tap` argument. This is useful, for example, if you need to adjust the time zone of a `datetime` range filter.
+
+```ruby
+
+class PostsController < ApplicationController
+  include Sift
+
+  filter_on :expiration, type: :datetime, tap: ->(value, params) {
+    value.split("...").
+      map do |str|
+        str.to_date.in_time_zone(LOCAL_TIME_ZONE)
+      end.
+      join("...")
+  }
+end
+```
+
 ### Filter on jsonb column
 
 Usually JSONB columns stores values as an Array or an Object (key-value), in both cases the parameter needs to be sent in a JSON format

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Scopes that accept no arguments are currently not supported.
 
 #### Accessing Params with Filter Scopes
 
-Filters with `type: :scope` have access to the params hash by passing in the desired keys to the `scope_params`. The keys passed in will be returned as a hash with their associated values, and should always appear as the last argument in your scope.
+Filters with `type: :scope` have access to the params hash by passing in the desired keys to the `scope_params`. The keys passed in will be returned as a hash with their associated values.
 
 ```ruby
 class Post < ActiveRecord::Base
@@ -131,6 +131,7 @@ The following types support ranges
 - datetime
 
 ### Mutating Filters
+
 Filters can be mutated before the filter is applied using the `tap` argument. This is useful, for example, if you need to adjust the time zone of a `datetime` range filter.
 
 ```ruby

--- a/lib/procore-sift.rb
+++ b/lib/procore-sift.rb
@@ -66,8 +66,8 @@ module Sift
   end
 
   class_methods do
-    def filter_on(parameter, type:, internal_name: parameter, default: nil, validate: nil, scope_params: [])
-      filters << Filter.new(parameter, type, internal_name, default, validate, scope_params)
+    def filter_on(parameter, type:, internal_name: parameter, default: nil, validate: nil, scope_params: [], tap: nil)
+      filters << Filter.new(parameter, type, internal_name, default, validate, scope_params, tap)
     end
 
     def filters

--- a/lib/sift/sort.rb
+++ b/lib/sift/sort.rb
@@ -17,6 +17,7 @@ module Sift
     def initialize(param, type, internal_name = param, scope_params = [])
       raise "unknown filter type: #{type}" unless WHITELIST_TYPES.include?(type)
       raise "scope params must be an array" unless scope_params.is_a?(Array)
+
       @parameter = Parameter.new(param, type, internal_name)
       @scope_params = scope_params
     end

--- a/lib/sift/subset_comparator.rb
+++ b/lib/sift/subset_comparator.rb
@@ -5,6 +5,8 @@ module Sift
     end
 
     def include?(other)
+      other = [other] unless other.is_a?(Array)
+
       @array.to_set >= other.to_set
     end
   end

--- a/lib/sift/version.rb
+++ b/lib/sift/version.rb
@@ -1,3 +1,3 @@
 module Sift
-  VERSION = "0.15.0".freeze
+  VERSION = "0.16.0".freeze
 end

--- a/test/dummy/app/controllers/posts_controller.rb
+++ b/test/dummy/app/controllers/posts_controller.rb
@@ -1,6 +1,8 @@
 class PostsController < ApplicationController
   include Sift
 
+  LOCAL_TIME_ZONE = "America/New_York"
+
   filter_on :id, type: :int
   filter_on :priority, type: :int
   filter_on :rating, type: :decimal
@@ -16,6 +18,14 @@ class PostsController < ApplicationController
 
   filter_on :french_bread, type: :string, internal_name: :title
   filter_on :body2, type: :scope, internal_name: :body2, default: ->(c) { c.order(:body) }
+
+  filter_on :expiration, type: :datetime, tap: ->(value, params) {
+    value.split("...").
+      map do |str|
+        str.to_date.in_time_zone(LOCAL_TIME_ZONE)
+      end.
+      join("...")
+  }
 
   # rubocop:disable Style/RescueModifier
   filter_on :id_array, type: :int, internal_name: :id, validate: ->(validator) {

--- a/test/filter_test.rb
+++ b/test/filter_test.rb
@@ -75,4 +75,12 @@ class FilterTest < ActiveSupport::TestCase
 
     assert_equal expected_validation, filter.validation(nil)
   end
+
+  test "it accepts a tap parameter" do
+    filter = Sift::Filter.new("hi", :boolean, "hi", nil, nil, [], ->(_value, _params) {
+      false
+    })
+
+    assert_equal false, filter.instance_variable_get("@tap").call(true, {})
+  end
 end

--- a/test/filtrator_test.rb
+++ b/test/filtrator_test.rb
@@ -197,4 +197,39 @@ class FiltratorTest < ActiveSupport::TestCase
 
     assert_equal Post.expired_before_ordered_by_body("2017-12-31", :asc).to_a, collection.to_a
   end
+
+  test "it can utilize the tap parameter to mutate a param" do
+    Post.create!(priority: 5, expiration: "2017-01-01T00:00:00+00:00")
+    Post.create!(priority: 5, expiration: "2017-01-02T00:00:00+00:00")
+    Post.create!(priority: 7, expiration: "2020-10-20T00:00:00+00:00")
+
+    filter = Sift::Filter.new(
+      :expiration,
+      :datetime,
+      :expiration,
+      nil,
+      nil,
+      [],
+      ->(value, params) {
+        if params[:mutate].present?
+          "2017-01-02T00:00:00+00:00...2017-01-02T00:00:00+00:00"
+        else
+          value
+        end
+      },
+    )
+    collection = Sift::Filtrator.filter(
+      Post.all,
+      {
+        filters: { expiration: "2017-01-01...2017-01-01" },
+        mutate: true
+      },
+      [filter],
+    )
+
+    assert_equal 3, Post.count
+    assert_equal 1, collection.count
+
+    assert_equal Post.where(expiration: "2017-01-02").to_a, collection.to_a
+  end
 end

--- a/test/filtrator_test.rb
+++ b/test/filtrator_test.rb
@@ -232,4 +232,37 @@ class FiltratorTest < ActiveSupport::TestCase
 
     assert_equal Post.where(expiration: "2017-01-02").to_a, collection.to_a
   end
+
+  test "it can filter on scopes that need multiple values from params with a tap" do
+    Post.create!(priority: 5, expiration: "2017-01-01")
+    Post.create!(priority: 5, expiration: "2017-01-02")
+    Post.create!(priority: 7, expiration: "2020-10-20")
+
+    filter = Sift::Filter.new(
+      :ordered_expired_before_and_priority,
+      :scope,
+      :ordered_expired_before_and_priority,
+      nil,
+      nil,
+      [:date, :priority],
+      ->(_value, _params) {
+        "ASC"
+      },
+    )
+    collection = Sift::Filtrator.filter(
+      Post.all,
+      {
+        filters: { ordered_expired_before_and_priority: "DESC" },
+        priority: 5,
+        date: "2017-12-31"
+      },
+      [filter],
+    )
+
+    assert_equal 3, Post.count
+    assert_equal 2, Post.ordered_expired_before_and_priority("ASC", date: "2017-12-31", priority: 5).count
+    assert_equal 2, collection.count
+
+    assert_equal Post.ordered_expired_before_and_priority("ASC", date: "2017-12-31", priority: 5).to_a, collection.to_a
+  end
 end


### PR DESCRIPTION
Adds a `tap` method to `filter_on`, to allow mutating the filter parameters before they are applied to the collection.

This supports a use case in which we don't necessarily want to change the filters the consumer sends, but we need to normalize the filters in some way before applying.  For example, consider a client that sends filters daterange filters in UTC, but applied to some data in a localized time zone.

This can currently be accomplished using a type of `:scope`; however, then the filters will not be validated and custom validation is required. 

We remove the README note that `scope_params` should be the last argument. We add a test to make sure this isn't the case; and it is fine to have tap be the last argument.

**Note** that this also resolves the red master build; see the change in `subset_comparator.rb`.

Bumps version. to 0.16.0.