### PR TITLE
Add ActiveRecord 7 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 0.17.0
+
+- Add support for Rails 7.0
+
 ## 0.16.0
 
 - Adds a `tap` method to `filter_on` to support mutating filter values

--- a/lib/sift/filter_validator.rb
+++ b/lib/sift/filter_validator.rb
@@ -52,7 +52,7 @@ module Sift
 
     def to_type(filter)
       if filter.type == :boolean
-        if ActiveRecord.gem_version >= '5.0'
+        if ActiveRecord::VERSION::MAJOR >= 5
           ActiveRecord::Type::Boolean.new.cast(filter_params[filter.param])
         else
           ActiveRecord::Type::Boolean.new.type_cast_from_user(filter_params[filter.param])

--- a/lib/sift/filter_validator.rb
+++ b/lib/sift/filter_validator.rb
@@ -52,7 +52,7 @@ module Sift
 
     def to_type(filter)
       if filter.type == :boolean
-        if Rails.version.starts_with?('5') || Rails.version.starts_with?('6')
+        if ActiveRecord.gem_version >= '5.0'
           ActiveRecord::Type::Boolean.new.cast(filter_params[filter.param])
         else
           ActiveRecord::Type::Boolean.new.type_cast_from_user(filter_params[filter.param])

--- a/lib/sift/value_parser.rb
+++ b/lib/sift/value_parser.rb
@@ -69,7 +69,7 @@ module Sift
     end
 
     def boolean_value
-      if ActiveRecord.gem_version >= '5.0'
+      if ActiveRecord::VERSION::MAJOR >= 5
         ActiveRecord::Type::Boolean.new.cast(value)
       else
         ActiveRecord::Type::Boolean.new.type_cast_from_user(value)

--- a/lib/sift/value_parser.rb
+++ b/lib/sift/value_parser.rb
@@ -69,7 +69,7 @@ module Sift
     end
 
     def boolean_value
-      if Rails.version.to_i >= 5
+      if ActiveRecord.gem_version >= '5.0'
         ActiveRecord::Type::Boolean.new.cast(value)
       else
         ActiveRecord::Type::Boolean.new.type_cast_from_user(value)

--- a/lib/sift/version.rb
+++ b/lib/sift/version.rb
@@ -1,3 +1,3 @@
 module Sift
-  VERSION = "0.16.0".freeze
+  VERSION = "0.17.0".freeze
 end


### PR DESCRIPTION
Fix `NoMethodError: undefined method 'type_cast_from_user'` error that occurs when using Sift on Rails 7.