### PR TITLE
Fix jsonb array filtering

### DIFF
--- a/lib/sift/where_handler.rb
+++ b/lib/sift/where_handler.rb
@@ -15,7 +15,7 @@ module Sift
     private
 
     def apply_jsonb_conditions(collection, value)
-      return collection.where("#{@param.internal_name} @> ?", val.to_s) if value.is_a?(Array)
+      return collection.where("#{@param.internal_name} @> ?", value.to_s) if value.is_a?(Array)
 
       value.each do |key, val|
         collection = if val.is_a?(Array)

--- a/sift.gemspec
+++ b/sift.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry"
   s.add_development_dependency "rails", ">= 7.0"
   s.add_development_dependency "rake"
+  s.add_development_dependency "minitest", "< 6"
   s.add_development_dependency "rubocop", "~> 1.68"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "appraisal"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,6 @@ require File.expand_path("../test/dummy/config/environment.rb", __dir__)
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 require "rails/test_help"
 require 'minitest/autorun'
-require 'minitest/mock'
 
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ require File.expand_path("../test/dummy/config/environment.rb", __dir__)
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 require "rails/test_help"
 require 'minitest/autorun'
+require 'minitest/mock'
 
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.

--- a/test/where_handler_test.rb
+++ b/test/where_handler_test.rb
@@ -1,9 +1,7 @@
-require "minitest/autorun"
-require "sift/parameter"
-require "sift/where_handler"
+require "test_helper"
 
-class WhereHandlerTest < Minitest::Test
-  def test_it_filters_jsonb_arrays_with_the_full_value
+class WhereHandlerTest < ActiveSupport::TestCase
+  test "it filters jsonb arrays with the full value" do
     param = Sift::Parameter.new(:metadata, :jsonb)
     collection = Minitest::Mock.new
     filtered_collection = Object.new

--- a/test/where_handler_test.rb
+++ b/test/where_handler_test.rb
@@ -1,0 +1,17 @@
+require "minitest/autorun"
+require "sift/parameter"
+require "sift/where_handler"
+
+class WhereHandlerTest < Minitest::Test
+  def test_it_filters_jsonb_arrays_with_the_full_value
+    param = Sift::Parameter.new(:metadata, :jsonb)
+    collection = Minitest::Mock.new
+    filtered_collection = Object.new
+    collection.expect :where, filtered_collection, ["metadata @> ?", "[1, 2]"]
+
+    result = Sift::WhereHandler.new(param).call(collection, [1, 2], {}, [])
+
+    assert_same filtered_collection, result
+    assert_mock collection
+  end
+end


### PR DESCRIPTION
Fixes jsonb array filtering by using the incoming array value in the containment predicate, and adds regression coverage for that path.

Checklist:

* [x] I have updated the necessary documentation
* [x] I have updated the changelog, if necessary (CHANGELOG.md)
* [x] I have signed off all my commits as required by [DCO](../CONTRIBUTING.md)
* [x] My build is green

Testing:

* [x] `bundle exec ruby -Itest test/where_handler_test.rb`
* [x] `bundle exec rake test`
* [x] `bundle exec rubocop --display-cop-names`

#created-by-ai

Made with [Cursor](https://cursor.com)