### PR TITLE
Add issues: write permission to Auto Author Assign workflow

### DIFF
--- a/.github/workflows/auto-assign-author.yml
+++ b/.github/workflows/auto-assign-author.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write
 
 jobs:
   assign:


### PR DESCRIPTION
## Summary
- The `Auto Author Assign` workflow has been failing on every PR with `Resource not accessible by integration` when calling [POST /repos/{owner}/{repo}/issues/{issue_number}/assignees](https://docs.github.com/rest/issues/assignees#add-assignees-to-an-issue).
- That endpoint requires `issues: write`, but the workflow only granted `pull-requests: write`. Added the missing scope (minimum-privilege fix; kept `pull-requests: write` for forward-compat with future action features like labels/reviewers).

## Test plan
- [x] `yq '.permissions' .github/workflows/auto-assign-author.yml` returns both `pull-requests: write` and `issues: write`.
- [x] YAML still parses; `on:`, `jobs.assign`, and the step's `uses`/`with` are unchanged.
- [ ] After merge: open a test PR and confirm the `Auto Author Assign / assign` job is green and the PR author appears under Assignees.

