### PR TITLE
Pin GitHub Actions in release workflow to commit SHAs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,10 +9,10 @@ jobs:
     outputs:
       changed: ${{ steps.check.outputs.any_changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - name: Check if version has been updated
         id: check
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@934b2d2c7e653bb8c968afed5a0428617f09aa24 # v44
         with:
           files: lib/sift/version.rb
   release:
@@ -20,19 +20,19 @@ jobs:
     needs: version-check
     if: ${{ github.event_name == 'workflow_dispatch' || needs.version-check.outputs.changed == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           ruby-version: 3.2
           bundler-cache: true
       - name: Build gem file
         run: bundle exec rake build
-      - uses: fac/ruby-gem-setup-credentials-action@v2
+      - uses: fac/ruby-gem-setup-credentials-action@5f62d5f2f56a11c7422a92f81fbb29af01e1c00f # v2
         with:
           user: ""
           key: rubygems
           token: ${{ secrets.RUBY_GEMS_API_KEY }}
-      - uses: fac/ruby-gem-push-action@v2
+      - uses: fac/ruby-gem-push-action@b2b56ea12bd8eb96b1add0befca8a9726b652078 # v2
         with:
           key: rubygems


### PR DESCRIPTION
## Summary

- The `procore-oss` org enforces that all GitHub Actions must be pinned to a full-length commit SHA (a supply-chain security measure). The `Release` workflow used mutable tags (`@v4`, `@v44`, `@v1`, `@v2`) and was therefore **blocked on every push to `main`**, failing in ~7s before doing any work.
- This is why gem **1.1.0 was never published** — `lib/sift/version.rb` on `main` reads `1.1.0`, but RubyGems' latest `procore-sift` is still `1.0.0`.
- Pins each action to the exact commit its tag currently points to, matching the [`procore-oss/blueprinter`](https://github.com/procore-oss/blueprinter/blob/main/.github/workflows/release.yaml) release workflow. No behavior change beyond making the references immutable.

| Action | Pinned SHA |
|--------|------------|
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` # v4 |
| `tj-actions/changed-files` | `934b2d2c7e653bb8c968afed5a0428617f09aa24` # v44 |
| `ruby/setup-ruby` | `9eb537ca036ebaed86729dcb9309076e4c5c3b74` # v1 |
| `fac/ruby-gem-setup-credentials-action` | `5f62d5f2f56a11c7422a92f81fbb29af01e1c00f` # v2 |
| `fac/ruby-gem-push-action` | `b2b56ea12bd8eb96b1add0befca8a9726b652078` # v2 |

## Test plan

- [ ] Confirm the `Release` workflow no longer fails the action-pinning check after this merges.
- [ ] Note: merging this alone will **not** publish 1.1.0 (no `version.rb` change in this push). Publish 1.1.0 by manually running the workflow: `gh workflow run release.yaml --ref main`.


Made with [Cursor](https://cursor.com)