### PR TITLE
Add allowed_push_host to gemspec so releases can publish

### DIFF
--- a/sift.gemspec
+++ b/sift.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.description = "A declarative DSL for building filters and sorts with Rails and Active Record"
   s.license     = "MIT"
 
+  s.metadata["allowed_push_host"] = "https://rubygems.org"
+
   s.files = Dir["{app,config,db,lib}/**/*",
                 "MIT-LICENSE",
                 "Rakefile",


### PR DESCRIPTION
## Summary

- After pinning the workflow actions (#87), the `Release` workflow now runs, but the **gem push step fails**:
  > `Push host is missing! Set spec.metadata['allowed_push_host'] in your gemspec`
- `sift.gemspec` declared no `metadata` at all. This adds `s.metadata["allowed_push_host"] = "https://rubygems.org"`, matching [`procore-oss/blueprinter`](https://github.com/procore-oss/blueprinter/blob/main/blueprinter.gemspec), which lets `fac/ruby-gem-push-action` publish.
- Verified locally: `gem build sift.gemspec` succeeds and produces `procore-sift-1.1.0.gem`.

## Test plan

- [ ] Merge, then run the release manually: `gh workflow run release.yaml --ref main`.
- [ ] Confirm `procore-sift` **1.1.0** appears on RubyGems (currently latest is 1.0.0).

Made with [Cursor](https://cursor.com)