### PR TITLE
Fix release job Ruby version to match new floor

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.3
           bundler-cache: true
       - name: Build gem file
         run: bundle exec rake build


### PR DESCRIPTION
## Summary

Follow-up to #89. The release job pinned `ruby-version: 3.2`, but that PR
raised the gem floor to `required_ruby_version >= 3.3.0`. When the version
bump merged and triggered the release, `bundle install` failed:

```
Because every version of procore-sift depends on Ruby >= 3.3.0
...
current Ruby version is = 3.2.11, version solving has failed.
```

Bumps the release job to Ruby 3.3 to match the floor.

Checklist:

* [x] I have updated the necessary documentation
* [x] I have updated the changelog, if necessary (CHANGELOG.md)
* [x] I have signed off all my commits as required by DCO
* [x] My build is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)