### PR TITLE
Grant contents:write to release job so version tags can be pushed

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,8 @@ on:
     types: [completed]
     branches: [main]
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   version-check:
     runs-on: ubuntu-latest
@@ -20,6 +22,8 @@ jobs:
           files: lib/sift/version.rb
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # fac/ruby-gem-push-action pushes a version tag
     needs: version-check
     if: ${{ github.event_name == 'workflow_dispatch' || needs.version-check.outputs.changed == 'true' }}
     steps:


### PR DESCRIPTION
## Summary

Follow-up to #89/#90. The 1.2.0 release **published to rubygems successfully**, but the final step — pushing the git version tag — failed:

```
remote: Permission to procore-oss/sift.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/procore-oss/sift/': 403
```

`fac/ruby-gem-push-action` tags by default, but the default `GITHUB_TOKEN` is read-only. This adds a workflow-wide `contents: read` default and scopes `contents: write` to the `release` job only (least privilege — tighter than relying on the repo-wide "Read and write" Settings toggle).

The missing `v1.2.0` tag has been pushed manually (points at the #89 merge commit that published the gem).

Checklist:

* [x] I have updated the necessary documentation
* [x] I have updated the changelog, if necessary (CHANGELOG.md)
* [x] I have signed off all my commits as required by DCO
* [x] My build is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)