### PR TITLE
Fix: blank filter values no longer activate their filter (1.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 1.2.1
+
+- Fix: a blank filter value (`nil` / `""` / `[]`) no longer activates its filter. 1.2.0 activated a filter whenever its param key was present, so an empty value produced conditions like `WHERE col = ''` — harmless on some string columns, but a 500 (`PG::InvalidTextRepresentation`) on integer/uuid columns and unintended narrowing (`WHERE col IN ()`) elsewhere. Blank values are now skipped again (pre-1.2 behavior). A literal boolean `false` is still treated as an active value, preserving the #58 fix.
+
 ## 1.2.0
 
 ### Breaking changes:

--- a/lib/sift/filtrator.rb
+++ b/lib/sift/filtrator.rb
@@ -46,8 +46,20 @@ module Sift
 
     def active_filters
       filters.select do |filter|
-        filter_params.include?(filter.param) || filter.default || filter.always_active?
+        active_filter_param?(filter) || filter.default || filter.always_active?
       end
+    end
+
+    # A filter is active when its param is present AND carries a meaningful value.
+    # A literal `false` is meaningful (a boolean filter value — see #58), but a
+    # blank value (nil / "" / []) leaves the filter inactive, matching pre-1.2
+    # behavior. Prior to this, any present key activated the filter, so an empty
+    # value produced conditions like `WHERE col = ''` (a 500 on non-string columns).
+    def active_filter_param?(filter)
+      return false unless filter_params.include?(filter.param)
+
+      value = filter_params[filter.param]
+      value == false || value.present?
     end
   end
 end

--- a/lib/sift/version.rb
+++ b/lib/sift/version.rb
@@ -1,3 +1,3 @@
 module Sift
-  VERSION = "1.2.0".freeze
+  VERSION = "1.2.1".freeze
 end

--- a/test/filtrator_test.rb
+++ b/test/filtrator_test.rb
@@ -31,6 +31,20 @@ class FiltratorTest < ActiveSupport::TestCase
     assert_equal Post.where(visible: false), collection
   end
 
+  test "it does not activate a filter when the value is blank" do
+    post = Post.create!(title: "hello")
+    filter = Sift::Filter.new(:title, :string, :title, nil)
+
+    # A blank value (nil / "" / []) must leave the filter inactive so the full
+    # collection is returned, rather than applying e.g. `WHERE title = ''`
+    # (which 500s on non-string columns).
+    ["", nil, []].each do |blank|
+      collection = Sift::Filtrator.filter(Post.all, { filters: { title: blank } }, [filter])
+
+      assert_equal [post], collection.to_a, "blank value #{blank.inspect} should leave the filter inactive"
+    end
+  end
+
   test "it will not try to make a range out of a string field that includes ..." do
     post = Post.create!(title: "wow...man")
     filter = Sift::Filter.new(:title, :string, :title, nil)


### PR DESCRIPTION
## Why

`1.2.0` changed `Filtrator#active_filters` so a filter activates whenever its param **key is present**, regardless of the value. This means a *blank* value (`nil`, `""`, `[]`) now activates the filter — which the pre-1.2 code deliberately skipped.

In practice that turns an empty filter into a real SQL predicate:

- `WHERE col = ''` — harmless on some string columns, but a **500 (`PG::InvalidTextRepresentation`)** on integer / uuid columns.
- `WHERE col IN ()` — unintended narrowing to zero rows.
- undefined scopes invoked with a blank arg — `NoMethodError`.

Blank filter values are extremely common (a UI sends `filters[status]=` for an unselected dropdown), so consumers on `1.2.0` see production errors on ordinary requests.

## What

Restore the pre-1.2 rule that a **blank value leaves its filter inactive**, while keeping the `1.2.0` fix that a literal boolean `false` *is* a meaningful, active value (#58).

`active_filters` now activates a filter only when:

```ruby
value == false || value.present?
```

so `false` still filters, but `nil` / `""` / `[]` no longer do.

## Testing

- Added a Filtrator test asserting blank values (`""`, `nil`, `[]`) leave the filter inactive and return the full collection. This fails on `1.2.0` and passes here.
- The existing "filters by boolean field even when the value is false" test still passes, guarding the #58 behavior.

Bumps the version to `1.2.1` and adds a CHANGELOG entry.
